### PR TITLE
Fix undefined behavior issues in aarch64

### DIFF
--- a/src/aarch64/Ginit.c
+++ b/src/aarch64/Ginit.c
@@ -46,8 +46,12 @@ unw_addr_space_t unw_local_addr_space = &local_addr_space;
 static inline void *
 uc_addr (unw_tdep_context_t *uc, int reg)
 {
-  if (reg >= UNW_AARCH64_X0 && reg < UNW_AARCH64_V0)
+  if (reg >= UNW_AARCH64_X0 && reg < UNW_AARCH64_X30)
     return &uc->uc_mcontext.regs[reg];
+  else if (reg == UNW_AARCH64_SP)
+    return &uc->uc_mcontext.sp;
+  else if (reg == UNW_AARCH64_PC)
+    return &uc->uc_mcontext.pc;
   else if (reg >= UNW_AARCH64_V0 && reg <= UNW_AARCH64_V31)
     return &GET_FPCTX(uc)->vregs[reg - UNW_AARCH64_V0];
   else


### PR DESCRIPTION
This is to facilitate [SERVER-84627](https://jira.mongodb.org/browse/SERVER-84627). EVG patch is [here](https://spruce.mongodb.com/version/66918398ea4433000718d085/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and shows that we don't get any failures due to libunwind.